### PR TITLE
Fix typo in README.md

### DIFF
--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -20,7 +20,7 @@ See images with `docker image ls`
 
 ### Example run 
 
-`docker run --env-file envfile run ghcr.io/nf-osi/jobs-snapshot syn27242487 syn27242485`
+`docker run --env-file envfile ghcr.io/nf-osi/jobs-snapshot syn27242487 syn27242485`
 
 ### To do
 

--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -20,7 +20,9 @@ See images with `docker image ls`
 
 ### Example run 
 
-`docker run --env-file envfile ghcr.io/nf-osi/jobs-snapshot syn27242487 syn27242485`
+Note: replace the ids with your own test entities in case the example tables no longer exist
+
+`docker run --env-file envfile ghcr.io/nf-osi/jobs-snapshot syn51907919 syn25585549`
 
 ### To do
 


### PR DESCRIPTION
Corrected the snapshot's Docker run command in the README file by removing the unintended "run" keyword.